### PR TITLE
Ignore bogus requests from Chrome during capture

### DIFF
--- a/go/src/wel/services/proxy/hijack.go
+++ b/go/src/wel/services/proxy/hijack.go
@@ -103,6 +103,7 @@ func hijackConnect(req *http.Request, clientConn net.Conn, proxyServer *ProxySer
 		if session.CurrentCaptureSession != nil {
 			session.CurrentCaptureSession.IncrementHostRequests(host)
 		}
+
 		broadcastIfPossible(ws.NewProxyConnectionRequestMessage(host))
 
 		if clientReq.Header.Get("Upgrade") == "websocket" {
@@ -197,13 +198,16 @@ func hijackConnect(req *http.Request, clientConn net.Conn, proxyServer *ProxySer
 		}
 
 		if session.CurrentCaptureSession != nil {
-			session.CurrentCaptureSession.Timeline.AddRequest(
-				clientReq.URL.String(),
-				resp.StatusCode,
-				resp.Header.Get("Content-Type"),
-				resp.Header.Get("Content-Encoding"),
-				outputFileId,
-			)
+			// Don't write the Chrome tracking and account requests
+			if clientReq.Host != "www.gstatic.com" && clientReq.Host != "accounts.google.com" {
+				session.CurrentCaptureSession.Timeline.AddRequest(
+					clientReq.URL.String(),
+					resp.StatusCode,
+					resp.Header.Get("Content-Type"),
+					resp.Header.Get("Content-Encoding"),
+					outputFileId,
+				)
+			}
 		}
 
 		// Send the response prelude to the client


### PR DESCRIPTION
Stop writing Chrome account and tracking requests to the capture timeline.

When we set up Chrome to proxy through the colluder during capture it will hit the Google account and static sites to check test whether the user is logged into a Google account and for Google-specific analytics on Chrome usage. This change simply looks for those requests and fails to write them to the capture timeline.

Note: The requests are still proxied, they're just not recorded so that they don't end up in the page formulations.
