### PR TITLE
Ensure `postinstall` works whether or not `.bin` pre-exists

### DIFF
--- a/package-src/package.json
+++ b/package-src/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/fullstorydev/web-embed-lab#readme",
   "scripts": {
-    "postinstall": "go-npm install && mv ./node_modules/.bin ../.bin && cp -R ./tmp/* ../.bin",
+    "postinstall": "go-npm install && mkdir -p ../.bin && mv ./node_modules/.bin/* ./tmp/* -t ../.bin",
     "preuninstall": "go-npm uninstall"
   },
   "goBinary": {

--- a/package-src/package.json
+++ b/package-src/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/fullstorydev/web-embed-lab#readme",
   "scripts": {
-    "postinstall": "go-npm install && mkdir -p ../.bin && mv ./node_modules/.bin/* ./tmp/* -t ../.bin",
+    "postinstall": "go-npm install && mkdir -p ../.bin && mv ./node_modules/.bin/* ./tmp/* ../.bin",
     "preuninstall": "go-npm uninstall"
   },
   "goBinary": {


### PR DESCRIPTION
This should help us ensure that we don't act differently on `postinstall` whether-or-not top-level `node_modules/.bin` already exists.